### PR TITLE
Refactored  across code, removed  and added docstring

### DIFF
--- a/src/mikrobloggeriet/cli.clj
+++ b/src/mikrobloggeriet/cli.clj
@@ -120,7 +120,6 @@
     | `git`         | Boolean specifying whether to create shelling out to git commands or not.
     | `editor`      | Specify editor to open when shell out.
     | `cohort-id`   | Keyword for the specifying cohort.
-    | `number` (Optional)   | Number for blog post. Added to try making the function more pure.
   
     Example:
     ```clojure
@@ -134,7 +133,7 @@
     (create-opts->commands sample-opts) 
     ```" 
   [opts]
-  (let [{:keys [dir git editor cohort-id number]} opts
+  (let [{:keys [dir git editor cohort-id]} opts
         git-user-email (:git.user/email opts)]
     (assert dir)
     (assert (some? git))
@@ -143,9 +142,8 @@
     (assert git-user-email)
     (assert cohort-id)
 
-    (let [cohort (store/cohorts cohort-id)
-          number (or number (store/cohort-doc-last-number cohort))
-          doc (doc/from-slug (str (cohort/slug cohort) "-" number))]
+    (let [cohort (store/cohorts cohort-id) 
+          doc (store/next-doc cohort)]
       (concat (when git
                 [[:shell {:dir dir} "git pull --ff-only"]])
               [[:create-dirs (store/doc-folder cohort doc)]

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -69,13 +69,6 @@
   (fs/file (doc-folder cohort doc)
            "meta.edn"))
 
-(declare docs)
-(defn cohort-doc-last-number [cohort]
-  (inc (or (->> (docs cohort)
-                last
-                doc/number)
-           0)))
-
 (defn cohort-href [cohort]
   (when (cohort/slug cohort)
     (str "/" (cohort/slug cohort)
@@ -98,3 +91,12 @@
            (map (comp doc/from-slug fs/file-name))
            (filter (partial doc-exists? cohort))
            (sort-by doc/number)))))
+
+(defn next-doc
+  "Creates a new doc for a cohort"
+  [cohort]
+  (let [number (inc (or (->> (docs cohort)
+                             last
+                             doc/number)
+                        0))]
+    (doc/from-slug (str (cohort/slug cohort) "-" number))))

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -39,11 +39,7 @@
    :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def cohorts 
-  ^:depricated
-  [olorm jals oj genai])
-
-(def cohorts-new (sorted-map :olorm olorm :jals jals :oj oj :genai genai))
+(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS
@@ -72,6 +68,13 @@
 (defn doc-meta-path [cohort doc]
   (fs/file (doc-folder cohort doc)
            "meta.edn"))
+
+(declare docs)
+(defn cohort-doc-last-number [cohort]
+  (inc (or (->> (docs cohort)
+                last
+                doc/number)
+           0)))
 
 (defn cohort-href [cohort]
   (when (cohort/slug cohort)


### PR DESCRIPTION
Etter tilbakemeldinger fra @teodorlu har jeg jobbet med å gjøre `create-opts->commands` pure. Har avgjort at det krever en del omstrukturering og blir fort mer forvirrende å lage denne fuksjonen, som jobber såpass tett på filsystemet pure at jeg lar den være (nesten) slik den er enn så lenge. Videre må man da også vurdere `today` og `uuid` funksjonen dersom man vil gjøre hele funksjonen pure.

Videre har jeg erstattet `cohorts` i `store.clj` helt med den nye koden (tidligere i `cohorts-new`. Jeg har også gjort noen små endringer i `create-opts->commmands` ved å flytte funksjonalitet for å hente tall for siste doc over til `store.clj`. La også til en docstring, og fjernet noen overføldige comments.