### PR TITLE
rel="self"-link bør linke til feeden, ikke bloggen

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -89,7 +89,7 @@
          slugs)))
 
 (defn rss-feed []
-  (let [title {:title "Mikrobloggeriet" :link "https://mikrobloggeriet.no"  :description "Mikrobloggeriet: der smått blir stort og hverdagsbetraktninger får mikroskopisk oppmerksomhet"}]
+  (let [title {:title "Mikrobloggeriet" :link "https://mikrobloggeriet.no" :feed-url "https://mikrobloggeriet.no/feed/" :description "Mikrobloggeriet: der smått blir stort og hverdagsbetraktninger får mikroskopisk oppmerksomhet"}]
     {:status 200
      :headers {"Content-type" "application/rss+xml"}
      :body (rss/channel-xml title


### PR DESCRIPTION
Om man validerer RSS-feeden med [validator.w3.org](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fmikrobloggeriet.no%2Ffeed%2F) blir man anbefalt å endre...

```xml
<atom:link href="https://mikrobloggeriet.no" rel="self" type="application/rss+xml"></atom:link>
```

...til å linke til selve feeden, og ikke hoved-url-en til nettstedet. (https://validator.w3.org/feed/docs/warning/SelfDoesntMatchLocation.html)

Heldigvis har vi allerede støtte for det i RSS-koden, om vi bare sender med `:feed-url`, slik jeg gjør i denne PR-en.

