### PR TITLE
`mblog create --no-edit`: Require less configuration

### DIFF
--- a/src/mikrobloggeriet/cli.clj
+++ b/src/mikrobloggeriet/cli.clj
@@ -268,7 +268,9 @@ Allowed options:
   --draft    EXPERIMENTAL! (may not work, stop working and/or change behavior)
 "))
     (System/exit 0))
-  (let [edit? (or (:edit opts) true)
+  (let [default-opts {:edit true}
+        opts (merge default-opts opts)
+        edit? (:edit opts) ;;
         required-properties (if edit?
                               #{:editor :cohort :repo-path}
                               #{:cohort :repo-path})]

--- a/src/mikrobloggeriet/cli.clj
+++ b/src/mikrobloggeriet/cli.clj
@@ -274,7 +274,7 @@ Allowed options:
                    git? (cond
                           (= (:git opts) true) true ;; if --git, then use git regardless.
                           (not edit?) false         ;; if unset and we're not editing, don't shell out to git
-                          :else (:git opts true)    ;; otherwise, take the CLI arg, and set to true if not set.
+                          :else (:git opts true)    ;; otherwise, take the CLI arg, and default to true
                           )]
                (assoc opts
                       :edit edit?

--- a/src/mikrobloggeriet/cli.clj
+++ b/src/mikrobloggeriet/cli.clj
@@ -272,9 +272,9 @@ Allowed options:
         opts (merge default-opts opts)
         opts (let [edit? (:edit opts true) ;; by default, we shell out to the user's editor to write.
                    git? (cond
-                          (= (:git opts) true) true ;; if --git, then use git regardless.
-                          (not edit?) false         ;; if unset and we're not editing, don't shell out to git
-                          :else (:git opts true)    ;; otherwise, take the CLI arg, and default to true
+                          (= (:git opts) true) true ;; if explicitly set in a CLI option, do what the user says.
+                          (not edit?) false         ;; otherwise, if the user has disabled editing, also disable Git.
+                          :else (:git opts true)    ;; otherwise, take the CLI arg, and default to true.
                           )]
                (assoc opts
                       :edit edit?


### PR DESCRIPTION
Don't require a valid configured `:editor` in this case. The --no-edit flag disables launching an editor, so it doesn't really require an editor to be set.

Aims to fix #42.

Doesn't work yet, don't merge.