### PR TITLE
Fjerne feature flagget for OJ

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -235,8 +235,6 @@
             [:p "Sett flagg: "
              (flag-element "ingen-flagg")
              " | "
-             (flag-element "oj")
-             " | "
              (flag-element "genai")
              ])])])}))
 


### PR DESCRIPTION
Feature flagget for OJ gjør ingenting nå, fordi OJ er en blogg. Conditionalen er også fjernet tidligere. Derfor fjerner jeg muligheten til å velge dette feature flagget.

Tror ikke det er noe mer som skal til for å fjerne dette flagget.. Krysser fingrene!