### PR TITLE
Added AOM cohort and added some christmas upgrades

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -149,9 +149,9 @@
        [:p "Teknologer fra Iterate deler fra hverdagen."]
        [:section
         [:h2 "Mikrobloggeriets Julekalender 2023"]
-        [:p "Mikrobloggen JUL skrives av Iterate-ansatte gjennom adventstida 2023."]
+        [:p "Mikrobloggen LUKE skrives av Iterate-ansatte gjennom adventstida 2023."]
         [:p
-         (let [cohort store/jul]
+         (let [cohort store/luke]
            (interpose " · "
                       (for [doc (->> (store/docs cohort)
                                      (map (fn [doc] (store/load-meta cohort doc)))
@@ -413,10 +413,10 @@
   (GET "/genai/" req (cohort-doc-table req store/genai))
   (GET "/genai/:slug/" req (doc req store/genai))
 
-  ;; JUL 
-  (GET "/jul/" req (cohort-doc-table req store/jul))
-  (GET "/jul/:slug/" req (doc req store/jul)) 
-  (GET "/jul/draw/:pool" req (draw req store/jul
+  ;; LUKE 
+  (GET "/luke/" req (cohort-doc-table req store/luke))
+  (GET "/luke/:slug/" req (doc req store/luke)) 
+  (GET "/luke/draw/:pool" req (draw req store/luke
                                     {\o "olav" \j "johan" \t "teodor" \h "håvard" \m "magnus" \l "lars"}))
   )
 

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -37,8 +37,8 @@
        [:style {:type "text/css"}
         (str ":root{ --text-color: var(--iterate-base0" number ")}")]))])
 
-(defn feeling-lucky []
-  [:a {:href "/random-doc" :class :feeling-lucky} "🎲"])
+(defn feeling-lucky [content]
+  [:a {:href "/random-doc" :class :feeling-lucky} content])
 
 (defn set-theme [req]
   (let [target "/"
@@ -107,7 +107,7 @@
    (into [:head] (shared-html-header req))
    [:body
     [:p
-     (feeling-lucky)
+     (feeling-lucky (if (= "god-jul" (flag req)) "🎄" "🎲"))
      " — "
      [:a {:href "/"} "mikrobloggeriet"]]
     [:h1 (str "Alle " (str/upper-case (cohort/slug cohort)) "-er")]
@@ -143,11 +143,21 @@
 
      (page/html5
       (into [:head] (shared-html-header req))
-      [:body
-       [:p (feeling-lucky)]
+      [:body 
+       [:p (feeling-lucky (if (= "god-jul" (flag req)) "🎄" "🎲"))]
        [:h1 "Mikrobloggeriet"]
        [:p "Teknologer fra Iterate deler fra hverdagen."]
-       [:section 
+       [:section
+        [:h2 "Advent of Mikrobloggeriet"]
+        [:p "AOM skrives av Iterate-ansatte gjennom adventstida 2023."]
+        [:p
+         (let [cohort store/aom]
+           (interpose " · "
+                      (for [doc (->> (store/docs cohort)
+                                     (map (fn [doc] (store/load-meta cohort doc)))
+                                     (remove doc-meta/draft?))]
+                        [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)])))]]
+       [:section
         [:h2 "OLORM"]
         [:p "Mikrobloggen OLORM skrives av Oddmund, Lars og Richard."]
         [:p
@@ -235,7 +245,9 @@
             [:p "Sett flagg: "
              (flag-element "ingen-flagg")
              " | "
-             (flag-element "genai")
+             (flag-element "genai") 
+             " | "
+             (flag-element "god-jul")
              ])])])}))
 
 (comment
@@ -264,7 +276,7 @@
         (into [:head] (concat (when title [[:title title]])
                               (shared-html-header req)))
         [:body
-         [:p (feeling-lucky)
+         [:p (feeling-lucky (if (= "god-jul" (flag req)) "🎄" "🎲"))
           " — "
           [:a {:href "/"} "mikrobloggeriet"]
           " "
@@ -339,7 +351,7 @@
                                             :background "black"
                                             :color neon-green})}
                 [:div (str "$ " old-command-name " draw " pool)]
-                [:div (str (get first-letter-names chosen) " 🎉")]]
+                [:div (str (get first-letter-names chosen) " 🎁")]]
 
                [:div {:style (style/inline {:margin-top "2rem"
                                             :font-family "monospace"
@@ -401,6 +413,11 @@
   (GET "/genai/" req (cohort-doc-table req store/genai))
   (GET "/genai/:slug/" req (doc req store/genai))
 
+  ;; AOM 
+  (GET "/aom/" req (cohort-doc-table req store/aom))
+  (GET "/aom/:slug/" req (doc req store/aom)) 
+  (GET "/aom/draw/:pool" req (draw req store/aom
+                                    {\o "olav" \j "johan" \t "teodor" \h "håvard" \m "magnus"}))
   )
 
 (comment

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -29,7 +29,7 @@
    (hiccup.page/include-css "/mikrobloggeriet.css")
    (let [theme (get-in (cookies/cookies-request req)
                        [:cookies "theme" :value]
-                       "vanilla")]
+                       "christmas")]
      (hiccup.page/include-css (str "/theme/" theme ".css")))
    (let [theme (get-in (cookies/cookies-request req) [:cookies "theme" :value])
          number (rand-nth (range 4))]
@@ -148,10 +148,10 @@
        [:h1 "Mikrobloggeriet"]
        [:p "Teknologer fra Iterate deler fra hverdagen."]
        [:section
-        [:h2 "Advent of Mikrobloggeriet"]
-        [:p "AOM skrives av Iterate-ansatte gjennom adventstida 2023."]
+        [:h2 "Mikrobloggeriets Julekalender 2023"]
+        [:p "Mikrobloggen JUL skrives av Iterate-ansatte gjennom adventstida 2023."]
         [:p
-         (let [cohort store/aom]
+         (let [cohort store/jul]
            (interpose " · "
                       (for [doc (->> (store/docs cohort)
                                      (map (fn [doc] (store/load-meta cohort doc)))
@@ -413,11 +413,11 @@
   (GET "/genai/" req (cohort-doc-table req store/genai))
   (GET "/genai/:slug/" req (doc req store/genai))
 
-  ;; AOM 
-  (GET "/aom/" req (cohort-doc-table req store/aom))
-  (GET "/aom/:slug/" req (doc req store/aom)) 
-  (GET "/aom/draw/:pool" req (draw req store/aom
-                                    {\o "olav" \j "johan" \t "teodor" \h "håvard" \m "magnus"}))
+  ;; JUL 
+  (GET "/jul/" req (cohort-doc-table req store/jul))
+  (GET "/jul/:slug/" req (doc req store/jul)) 
+  (GET "/jul/draw/:pool" req (draw req store/jul
+                                    {\o "olav" \j "johan" \t "teodor" \h "håvard" \m "magnus" \l "lars"}))
   )
 
 (comment

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -40,10 +40,10 @@
    :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def jul
+(def luke
   (sorted-map
-   :cohort/root "text/jul/2023"
-   :cohort/slug "jul"
+   :cohort/root "text/luke/2023"
+   :cohort/slug "luke"
    :cohort/members [{:author/email "42978548+olavm@users.noreply.github.com" :author/first-name "Olav"}
                     {:author/email "jomarn@me.com" :author/first-name "Johan"}
                     {:author/email "git@teod.eu", :author/first-name "Teodor"}
@@ -53,7 +53,7 @@
                     {:author/first-name "Håvard"}
                     {:author/first-name "Thusan"}]))
 
-(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :jul jul))
+(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :luke luke))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -40,19 +40,20 @@
    :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def aom
+(def jul
   (sorted-map
-   :cohort/root "text/aom"
-   :cohort/slug "aom"
+   :cohort/root "text/jul/2023"
+   :cohort/slug "jul"
    :cohort/members [{:author/email "42978548+olavm@users.noreply.github.com" :author/first-name "Olav"}
                     {:author/email "jomarn@me.com" :author/first-name "Johan"}
                     {:author/email "git@teod.eu", :author/first-name "Teodor"}
+                    {:author/email "lars.barlindhaug@iterate.no", :author/first-name "Lars"}
                     {:author/first-name "Magnus"}
                     {:author/first-name "Julian"}
                     {:author/first-name "Håvard"}
                     {:author/first-name "Thusan"}]))
 
-(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :aom aom))
+(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :jul jul))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -40,7 +40,19 @@
    :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai))
+(def aom
+  (sorted-map
+   :cohort/root "text/aom"
+   :cohort/slug "aom"
+   :cohort/members [{:author/email "42978548+olavm@users.noreply.github.com" :author/first-name "Olav"}
+                    {:author/email "jomarn@me.com" :author/first-name "Johan"}
+                    {:author/email "git@teod.eu", :author/first-name "Teodor"}
+                    {:author/first-name "Magnus"}
+                    {:author/first-name "Julian"}
+                    {:author/first-name "Håvard"}
+                    {:author/first-name "Thusan"}]))
+
+(def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :aom aom))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS

--- a/theme/christmas.css
+++ b/theme/christmas.css
@@ -7,11 +7,11 @@
     --desktop-font-size: 1.2rem/1.55;
     --mobile-font-size: 1rem/1.45;
     --text-color: #2d2d2d;
-    --link-color: #dc0428; /* Red */
+    --link-color: #ff0000; /* Red */
     --link-color-alt: #009900; /* Forest Green */
     --primary-color: #8B0000; /* Dark Red */
-    --secondary-color: #009900; /* Forest Green */
-    --tertiary-color: gold;
+    --secondary-color: #99ff99; /* Forest Green */
+    --tertiary-color:  #ff7878;
 }
 
 /* Dark mode support */
@@ -22,10 +22,10 @@
     :root {
         --text-color: #cccccc;
         --link-color: #009900; /* Green */
-        --link-color-alt: #99ff99; /* Gold */
-        --primary-color: #FFA07A; /* Light Salmon */
+        --link-color-alt: #99ff99; /* Light green */
+        --primary-color: #ffff66; /* Light Yellow */
         --primary-color-light: #10101a;
-        --secondary-color: #32CD32; /* Lime Green */
+        --secondary-color: #10101a; /* Lime Green */
         --tertiary-color: #10101a;
     }
 }

--- a/theme/christmas.css
+++ b/theme/christmas.css
@@ -1,0 +1,31 @@
+/*
+ * AI 
+ */
+
+/* Variables */
+:root {
+    --desktop-font-size: 1.2rem/1.55;
+    --mobile-font-size: 1rem/1.45;
+    --text-color: #2d2d2d;
+    --link-color: #dc0428; /* Red */
+    --link-color-alt: #009900; /* Forest Green */
+    --primary-color: #8B0000; /* Dark Red */
+    --secondary-color: #009900; /* Forest Green */
+    --tertiary-color: gold;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #0f0f23;
+    }
+    :root {
+        --text-color: #cccccc;
+        --link-color: #009900; /* Green */
+        --link-color-alt: #99ff99; /* Gold */
+        --primary-color: #FFA07A; /* Light Salmon */
+        --primary-color-light: #10101a;
+        --secondary-color: #32CD32; /* Lime Green */
+        --tertiary-color: #10101a;
+    }
+}


### PR DESCRIPTION
God jul mine venner!
Vi kan klappe oss selv på skulderen nå. Etter refaktoreringsjobben vi gjorde i august var det en lek å legge til den nye adventskalenderkohorten **AOM**.

Håper dere kan se over at jeg har lagt til alt som trengs alle steder som trengs. Jeg har testet å opprette noen innlegg i mitt CLI, og ting ser ut som det funker som det skal.

Jeg håper vi kan få med så mange som mulig fra Iterate på Advent of Mikrobloggeriet denne juletiden. Jeg tenker å fortsette litt på julepynten av nettsida også, men regner med @JohanMartinEJohnsen også ikke er fremmed for å hjelpe til å pynte dette juletreet.

Det er noen features vi må se på på denne adventstida:
- Når man blir en del folk i en kohort er det fort flere personer har et navn som starter på samme bokstav. Dette støtter ikke dagens `draw`-funksjonalitet særlig bra.
- Vi må nok gjøre litt jobb for designerne dersom vi ønsker å ha de med. Jeg tenker det enkleste er fort å laste opp innlegg for de.

Jeg er forsåvidt ikke _gift_ med kohortnavnet AOM, så tar også i mot forslag. Vurderte og eksempelvis AOM23, AOM2023 osv, men ønsker nok heller å utvide funksjonaliteten i nettsiden til å kjøre et slags fil hierarki ala `mikrobloggeriet.no/aom/2023/aom-1...` og et filhierarki som dette:

```
.
└── text/
    └── aom/
        ├── 2023/
        │   ├── aom-1
        │   ├── aom-2
        │   ├── aom-3
        │   └── ...
        └── 2024/
            ├── aom-1
            ├── aom-2
            └── aom-3
```
