### PR TITLE
Make doc lists proper lists

### DIFF
--- a/mikrobloggeriet.css
+++ b/mikrobloggeriet.css
@@ -23,3 +23,16 @@ a.feeling-lucky {
         transform:rotate(360deg);
     }
 }
+
+ul.doc-list {
+    list-style-type: none;
+    padding: 0;
+
+    li {
+        display: inline list-item;
+    }
+
+    li + li::before {
+        content: " · ";
+    }
+}

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -147,43 +147,42 @@
        [:section
         [:h2 "Mikrobloggeriets Julekalender 2023"]
         [:p "Mikrobloggen LUKE skrives av Iterate-ansatte gjennom adventstida 2023."]
-        [:p
+        [:ul {:class "doc-list"}
          (let [cohort store/luke]
-           (interpose " · "
-                      (for [doc (->> (store/docs cohort)
-                                     (map (fn [doc] (store/load-meta cohort doc)))
-                                     (remove doc-meta/draft?))]
-                        [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)])))]]
+           (for [doc (->> (store/docs cohort)
+                          (map (fn [doc] (store/load-meta cohort doc)))
+                          (remove doc-meta/draft?))]
+             [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]]))]]
        [:section
         [:h2 "OLORM"]
         [:p "Mikrobloggen OLORM skrives av Oddmund, Lars, Richard og Teodor."]
-        [:p
+        [:ul {:class "doc-list"}
          (let [cohort store/olorm]
-           (interpose " · "
-                      (for [doc (->> (store/docs cohort)
-                                     (map (fn [doc] (store/load-meta cohort doc)))
-                                     (remove doc-meta/draft?))]
-                        [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)])))]]
+           (for [doc (->> (store/docs cohort)
+                          (map (fn [doc] (store/load-meta cohort doc)))
+                          (remove doc-meta/draft?))]
+             [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]]))]]
        [:section
         [:h2 "JALS"]
         [:p "Mikrobloggen JALS skrives av Adrian, Lars og Sindre. Jørgen har skrevet tidligere."]
-        [:p
+        [:ul {:class "doc-list"}
          (let [cohort store/jals]
-           (interpose " · "
-                      (for [doc (->> (store/docs cohort)
-                                     (map (fn [doc] (store/load-meta cohort doc)))
-                                     (remove doc-meta/draft?))]
-                        [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)])))]]
+
+           (for [doc (->> (store/docs cohort)
+                          (map (fn [doc] (store/load-meta cohort doc)))
+                          (remove doc-meta/draft?))]
+             [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]]))]]
 
        [:section
         [:h2 "OJ"]
         [:p "Mikrobloggen OJ skrives av Olav og Johan."]
-        (let [cohort store/oj]
-          (interpose " · "
-                     (for [doc (->> (store/docs cohort)
-                                    (map (fn [doc] (store/load-meta cohort doc)))
-                                    (remove doc-meta/draft?))]
-                       [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)])))]
+        [:ul {:class "doc-list"}
+         (let [cohort store/oj]
+
+           (for [doc (->> (store/docs cohort)
+                          (map (fn [doc] (store/load-meta cohort doc)))
+                          (remove doc-meta/draft?))]
+             [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]]))]]
 
        (when (= "genai" (flag req))
          [:section


### PR DESCRIPTION
Denne PR-en

- Gjør listene over _docs_ om til HTML-lister (i stedetfor avsnitt)
- Flytter "logikken" i hvordan listene skal se ut fra HTML til CSS

Dette er mer semantisk og kulere for accessibility, men gjør det også mulig å style dette i _themes_ om vi skulle ha lyst til det.

Såvidt jeg kan se, så er det ingen endringer i utseende fra denne PR-en.