### PR TITLE
Refactor: move store logic to store

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -128,18 +128,13 @@
          [:td (store/author-first-name cohort doc)]
          [:td (:doc/created doc)]])]]]))
 
-(defn default-doc-list [cohort]
-  [:ul {:class "doc-list"}
-   (for [doc (->> (store/docs cohort)
-                  (map (fn [doc] (store/load-meta cohort doc)))
-                  (remove doc-meta/draft?))]
-     [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]])])
-
 (defn default-cohort-section [cohort name description]
   [:section
    [:h2 name]
    [:p description]
-   (default-doc-list cohort)])
+   [:ul {:class "doc-list"}
+    (for [doc (store/published-docs-with-meta cohort)]
+      [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]])]])
 
 (defn index [req]
   (let [mikrobloggeriet-announce-url "https://garasjen.slack.com/archives/C05355N5TCL"

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -74,7 +74,7 @@
   (.toInstant
    (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (str date))))
 
-(defn docs->rss-map [cohort]
+(defn cohort-rss-section [cohort]
   (let [docs (store/docs cohort)
         slugs (map :doc/slug docs)]
     (map (fn [slug]
@@ -96,10 +96,10 @@
     {:status 200
      :headers {"Content-type" "application/rss+xml"}
      :body (rss/channel-xml title
-                            (docs->rss-map store/olorm)
-                            (docs->rss-map store/jals)
-                            (docs->rss-map store/oj)
-                            (docs->rss-map store/genai))}))
+                            (cohort-rss-section store/olorm)
+                            (cohort-rss-section store/jals)
+                            (cohort-rss-section store/oj)
+                            (cohort-rss-section store/genai))}))
 
 (defn cohort-doc-table [req cohort]
   (page/html5

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -77,19 +77,19 @@
 (defn cohort-rss-section [cohort]
   (let [docs (store/docs cohort)
         slugs (map :doc/slug docs)]
-    (map (fn [slug]
-           (let [doc (doc/from-slug slug)]
-             {:title slug
-              :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
-              :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
-              :category (cohort/slug cohort)
-              :description slug
-              :guid slug
-              "content:encoded" (str
-                                 "<![CDATA["
-                                 (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
-                                 "]]>")}))
-         slugs)))
+    (->> slugs
+         (map (fn [slug]
+                (let [doc (doc/from-slug slug)]
+                  {:title slug
+                   :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
+                   :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
+                   :category (cohort/slug cohort)
+                   :description slug
+                   :guid slug
+                   "content:encoded" (str
+                                      "<![CDATA["
+                                      (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
+                                      "]]>")}))))))
 
 (defn rss-feed []
   (let [title {:title "Mikrobloggeriet" :link "https://mikrobloggeriet.no" :feed-url "https://mikrobloggeriet.no/feed/" :description "Mikrobloggeriet: der smått blir stort og hverdagsbetraktninger får mikroskopisk oppmerksomhet"}]

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -75,21 +75,19 @@
    (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (str date))))
 
 (defn cohort-rss-section [cohort]
-  (let [docs (store/docs cohort)
-        slugs (map :doc/slug docs)]
-    (->> slugs
-         (map (fn [slug]
-                (let [doc (doc/from-slug slug)]
-                  {:title slug
-                   :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
-                   :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
-                   :category (cohort/slug cohort)
-                   :description slug
-                   :guid slug
-                   "content:encoded" (str
-                                      "<![CDATA["
-                                      (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
-                                      "]]>")}))))))
+  (let [docs (store/docs cohort)]
+    (->> docs
+         (map (fn [doc]
+                {:title (doc/slug doc)
+                 :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
+                 :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
+                 :category (cohort/slug cohort)
+                 :description (doc/slug doc)
+                 :guid (doc/slug doc)
+                 "content:encoded" (str
+                                    "<![CDATA["
+                                    (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
+                                    "]]>")})))))
 
 (defn rss-feed []
   (let [title {:title "Mikrobloggeriet" :link "https://mikrobloggeriet.no" :feed-url "https://mikrobloggeriet.no/feed/" :description "Mikrobloggeriet: der smått blir stort og hverdagsbetraktninger får mikroskopisk oppmerksomhet"}]

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -74,8 +74,9 @@
   (.toInstant
    (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (str date))))
 
-(defn docs->rss-map [docs cohort]
-  (let [slugs (map :doc/slug docs)]
+(defn docs->rss-map [cohort]
+  (let [docs (store/docs cohort)
+        slugs (map :doc/slug docs)]
     (map (fn [slug]
            (let [doc (doc/from-slug slug)]
              {:title slug
@@ -95,10 +96,10 @@
     {:status 200
      :headers {"Content-type" "application/rss+xml"}
      :body (rss/channel-xml title
-                            (docs->rss-map (store/docs store/olorm) store/olorm)
-                            (docs->rss-map (store/docs store/jals) store/jals)
-                            (docs->rss-map (store/docs store/oj) store/oj)
-                            (docs->rss-map (store/docs store/genai) store/genai))}))
+                            (docs->rss-map store/olorm)
+                            (docs->rss-map store/jals)
+                            (docs->rss-map store/oj)
+                            (docs->rss-map store/genai))}))
 
 (defn cohort-doc-table [req cohort]
   (page/html5

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -11,7 +11,6 @@
    [mikrobloggeriet.cache :as cache]
    [mikrobloggeriet.cohort :as cohort]
    [mikrobloggeriet.doc :as doc]
-   [mikrobloggeriet.doc-meta :as doc-meta]
    [mikrobloggeriet.http :as http]
    [mikrobloggeriet.pandoc :as pandoc]
    [mikrobloggeriet.store :as store]

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -133,7 +133,7 @@
    [:h2 name]
    [:p description]
    [:ul {:class "doc-list"}
-    (for [doc (store/published-docs-with-meta cohort)]
+    (for [doc (store/published-docs cohort)]
       [:li [:a {:href (store/doc-href cohort doc)} (:doc/slug doc)]])]])
 
 (defn index [req]

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -75,19 +75,17 @@
    (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (str date))))
 
 (defn cohort-rss-section [cohort]
-  (let [docs (store/docs cohort)]
-    (->> docs
-         (map (fn [doc]
-                {:title (doc/slug doc)
-                 :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
-                 :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
-                 :category (cohort/slug cohort)
-                 :description (doc/slug doc)
-                 :guid (doc/slug doc)
-                 "content:encoded" (str
-                                    "<![CDATA["
-                                    (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
-                                    "]]>")})))))
+  (for [doc (store/docs cohort)]
+    {:title (doc/slug doc)
+     :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
+     :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
+     :category (cohort/slug cohort)
+     :description (doc/slug doc)
+     :guid (doc/slug doc)
+     "content:encoded" (str
+                        "<![CDATA["
+                        (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))
+                        "]]>")}))
 
 (defn rss-feed []
   (let [title {:title "Mikrobloggeriet" :link "https://mikrobloggeriet.no" :feed-url "https://mikrobloggeriet.no/feed/" :description "Mikrobloggeriet: der smått blir stort og hverdagsbetraktninger får mikroskopisk oppmerksomhet"}]

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -163,10 +163,10 @@
            (filter (partial doc-exists? cohort))
            (sort-by doc/number)))))
 
-(defn published-docs-with-meta [cohort]
+(defn published-docs [cohort]
   (->> (docs cohort)
-       (map (fn [doc] (load-meta cohort doc)))
-       (remove doc-meta/draft?)))
+       (remove (fn [doc]
+                 (doc-meta/draft? (load-meta cohort doc))))))
 
 (defn next-doc
   "Creates a new doc for a cohort"

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -163,6 +163,11 @@
            (filter (partial doc-exists? cohort))
            (sort-by doc/number)))))
 
+(defn published-docs-with-meta [cohort]
+  (->> (docs cohort)
+       (map (fn [doc] (load-meta cohort doc)))
+       (remove doc-meta/draft?)))
+
 (defn next-doc
   "Creates a new doc for a cohort"
   [cohort]


### PR DESCRIPTION
Jeg synes det ble mye store-logikk i `mikrobloggeriet.serve`.

Denne PR-en flytter store-logikken til store. `default-doc-list` ble da tynn, så jeg tok implementasjonen inn i `default-cohort-section`.

Vil gjerne høre hva dere synes!