### PR TITLE
Urlog load ascii and create seperate components

### DIFF
--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -15,18 +15,18 @@
 
 (defn door+url->html [door url]
   [:div {:class :component}
-   [:pre "_|____|____|____|"]
-   [:a {:href url :class :door}
+   [:pre {:aria-hidden :true} "_|____|____|____|"]
+   [:a {:href url :class :door :aria-label "door ascii art"}
     [:pre {:class :closed}
      (:closed door)]
     [:pre {:class :open}
      (:open door)]]])
 
 (defn wall->html [wall]
-  [:pre wall])
+  [:pre {:aria-hidden :true} wall])
 
 (defn logo->html [logo]
-  [:pre {:class :logo} logo])
+  [:pre {:class :logo :aria-label "URLOG logo ascii art"} logo])
 
 
 (defn door-paths [doors-dir]
@@ -73,7 +73,7 @@
        (for [doc (reverse (:urlog/docs urlog-data))]
          (let [url (:urlog/url doc)
                door (rand-nth (:doors assets))]
-           [:div {:class :wall}
+           [:div {:class :wall :role :none}
             (wall->html (:wall assets))
             (door+url->html door url)
             (wall->html (:wall assets))]))]])))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -6,9 +6,9 @@
    [mikrobloggeriet.urlog :as urlog]))
 
 ;; TO-DO
-;; skille wall-html og door-html som seperate komponenter
-;; dra ut filinnlasting fra fra html komponentene
-;; lage load for å laste inn alle ascii txt assets
+;; rename komponenter slik at de gir mening
+;; rydde i css-filen, spesielt rundt "wall" klassen
+;; rydde opp i page, spesielt rundt random og reverse logikken
 ;; splitte i flere navnerom, eks view, store
 
 (def urlogfile-path "text/urlog/urls.edn")

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -55,8 +55,7 @@
 
 (defn page [_req]
   (let [urlog-data (edn/read-string (slurp urlogfile-path))
-        assets (load-ascii-assets assets-dir)
-        wall-html (wall->html (:wall assets))]
+        assets (load-ascii-assets assets-dir)]
     (page/html5
      [:head
       (page/include-css "/mikrobloggeriet.css")
@@ -75,6 +74,6 @@
          (let [url (:urlog/url doc)
                door (rand-nth (:doors assets))]
            [:div {:class :wall}
-            wall-html
+            (wall->html (:wall assets))
             (door+url->html door url)
-            wall-html]))]])))
+            (wall->html (:wall assets))]))]])))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -11,11 +11,7 @@
 ;; rydde opp i page, spesielt rundt random og reverse logikken
 ;; splitte i flere navnerom, eks view, store
 
-(def urlogfile-path "text/urlog/urls.edn")
-(def assets-dir "src/mikrobloggeriet/urlog_assets")
-(def doors-dir "src/mikrobloggeriet/urlog_assets/doors/")
-
-(defn door-paths []
+(defn door-paths [doors-dir]
   (->> (fs/list-dir doors-dir)
        (map str)
        (sort)))
@@ -24,10 +20,10 @@
   {:closed (slurp (str door-path "/closed.txt"))
    :open (slurp (str door-path "/open.txt"))})
 
-(defn load-ascii-assets []
+(defn load-ascii-assets [assets-dir]
   {:logo (slurp (str assets-dir "/logo.txt"))
    :wall (slurp (str assets-dir "/wall.txt"))
-   :doors (doall (map load-door (door-paths)))})
+   :doors (doall (map load-door (door-paths (str assets-dir "/doors/"))))})
 
 (defn feeling-lucky [content]
   [:a {:href "/random-doc" :class :feeling-lucky} content])
@@ -54,9 +50,12 @@
     (door+url->html door ""))
   (rand-nth (:doors load-ascii-assets)))
 
+(def urlogfile-path "text/urlog/urls.edn")
+(def assets-dir "src/mikrobloggeriet/urlog_assets")
+
 (defn page [_req]
   (let [urlog-data (edn/read-string (slurp urlogfile-path))
-        assets (load-ascii-assets)
+        assets (load-ascii-assets assets-dir)
         wall-html (wall->html (:wall assets))]
     (page/html5
      [:head

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -6,24 +6,9 @@
    [mikrobloggeriet.urlog :as urlog]))
 
 ;; TO-DO
-;; rename komponenter slik at de gir mening
 ;; rydde i css-filen, spesielt rundt "wall" klassen
 ;; rydde opp i page, spesielt rundt random og reverse logikken
 ;; splitte i flere navnerom, eks view, store
-
-(defn door-paths [doors-dir]
-  (->> (fs/list-dir doors-dir)
-       (map str)
-       (sort)))
-
-(defn load-door [door-path]
-  {:closed (slurp (str door-path "/closed.txt"))
-   :open (slurp (str door-path "/open.txt"))})
-
-(defn load-ascii-assets [assets-dir]
-  {:logo (slurp (str assets-dir "/logo.txt"))
-   :wall (slurp (str assets-dir "/wall.txt"))
-   :doors (doall (map load-door (door-paths (str assets-dir "/doors/"))))})
 
 (defn feeling-lucky [content]
   [:a {:href "/random-doc" :class :feeling-lucky} content])
@@ -42,6 +27,21 @@
 
 (defn logo->html [logo]
   [:pre {:class :logo} logo])
+
+
+(defn door-paths [doors-dir]
+  (->> (fs/list-dir doors-dir)
+       (map str)
+       (sort)))
+
+(defn load-door [door-path]
+  {:closed (slurp (str door-path "/closed.txt"))
+   :open (slurp (str door-path "/open.txt"))})
+
+(defn load-ascii-assets [assets-dir]
+  {:logo (slurp (str assets-dir "/logo.txt"))
+   :wall (slurp (str assets-dir "/wall.txt"))
+   :doors (doall (map load-door (door-paths (str assets-dir "/doors/"))))})
 
 (comment
   (logo->html (:logo load-ascii-assets))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -21,10 +21,6 @@
 (defn feeling-lucky [content]
   [:a {:href "/random-doc" :class :feeling-lucky} content])
 
-(defn logo []
-  [:pre {:class :logo}
-   (slurp "src/mikrobloggeriet/urlog_assets/logo.txt")])
-
 (def load-ascii
   {:logo (slurp "src/mikrobloggeriet/urlog_assets/logo.txt")
    :wall (slurp "src/mikrobloggeriet/urlog_assets/wall.txt")
@@ -56,18 +52,6 @@
     (door+url->html (:closed door) (:open door) ""))
   (rand-nth (:doors load-ascii)))
 
-(defn door-path+url->html [door-path url]
-  [:div {:class :wall}
-   [:pre (slurp "src/mikrobloggeriet/urlog_assets/wall.txt")]
-   [:div {:class :component}
-    [:pre "_|____|____|____|"]
-    [:a {:href url :class :door}
-     [:pre {:class :closed}
-      (slurp (str door-path "/closed.txt"))]
-     [:pre {:class :open}
-      (slurp (str door-path "/open.txt"))]]]
-   [:pre (slurp "src/mikrobloggeriet/urlog_assets/wall.txt")]])
-
 (defn page [_req]
   (page/html5
    [:head
@@ -79,12 +63,16 @@
      " — "
      [:a {:href "/"} "mikrobloggeriet"]]
     [:header
-     (logo)
+     (logo->html (:logo load-ascii))
      [:p {:class "intro"}
       "Tilfeldige dører til internettsteder som kan være morsomme og/eller interessante å besøke en eller annen gang."]]
     [:div {:class "all-doors"}
-     (let [urlog-data (edn/read-string (slurp urlogfile-path))]
+     (let [urlog-data (edn/read-string (slurp urlogfile-path))
+           wall (wall->html (:wall load-ascii))]
        (for [doc (reverse (:urlog/docs urlog-data))]
-         (let [door-path (rand-nth (door-paths))
+         (let [door (rand-nth (:doors load-ascii))
                url (:urlog/url doc)]
-           (door-path+url->html door-path url))))]]))
+           [:div {:class :wall}
+            wall
+            (door+url->html (:closed door) (:open door) url)
+            wall])))]]))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -25,6 +25,37 @@
   [:pre {:class :logo}
    (slurp "src/mikrobloggeriet/urlog_assets/logo.txt")])
 
+(def load-ascii
+  {:logo (slurp "src/mikrobloggeriet/urlog_assets/logo.txt")
+   :wall (slurp "src/mikrobloggeriet/urlog_assets/wall.txt")
+   :doors (map (fn [n] {:closed (slurp (str n "/closed.txt"))
+                        :open (slurp (str n "/open.txt"))}) (door-paths))})
+
+(defn door+url->html [closed open url]
+  [:div {:class :wall}
+   [:div {:class :component}
+    [:pre "_|____|____|____|"]
+    [:a {:href url :class :door}
+     [:pre {:class :closed}
+      closed]
+     [:pre {:class :open}
+      open]]]])
+
+(defn wall->html [wall]
+  [:div {:class :wall}
+   [:pre wall]])
+
+(defn logo->html [logo]
+  [:pre {:class :logo}
+   logo])
+
+(comment
+  (logo->html (:logo load-ascii))
+  (wall->html (:wall load-ascii))
+  (let [door (first (:doors load-ascii))]
+    (door+url->html (:closed door) (:open door) ""))
+  (rand-nth (:doors load-ascii)))
+
 (defn door-path+url->html [door-path url]
   [:div {:class :wall}
    [:pre (slurp "src/mikrobloggeriet/urlog_assets/wall.txt")]

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -28,7 +28,6 @@
 (defn logo->html [logo]
   [:pre {:class :logo :aria-label "URLOG logo ascii art"} logo])
 
-
 (defn door-paths [doors-dir]
   (->> (fs/list-dir doors-dir)
        (map str)
@@ -47,7 +46,7 @@
   (logo->html (:logo load-ascii-assets))
   (wall->html (:wall load-ascii-assets))
   (let [door (first (:doors load-ascii-assets))]
-    (door+url->html door ""))
+    (door+url->html door "example.com"))
   (rand-nth (:doors load-ascii-assets)))
 
 (def urlogfile-path "text/urlog/urls.edn")
@@ -71,8 +70,8 @@
         "Tilfeldige dører til internettsteder som kan være morsomme og/eller interessante å besøke en eller annen gang."]]
       [:div {:class :all-doors}
        (for [doc (reverse (:urlog/docs urlog-data))]
-         (let [url (:urlog/url doc)
-               door (rand-nth (:doors assets))]
+         (let [door (rand-nth (:doors assets))
+               url (:urlog/url doc)]
            [:div {:class :wall :role :none}
             (wall->html (:wall assets))
             (door+url->html door url)


### PR DESCRIPTION
Prøvde meg på å separere logikk for filinnlasting fra HTML-komponentene.

Nå skjer innlasting av alle urlog ascii assets i en `load-ascii`-funksjon.
Hver HTML-komponent tar inn ascii-strengen(ene) den skal vise som argumenter.

Det gjenstår nok litt opprydding i funksjonsnavn og struktur, før jeg skal begynne å se på å separere logikk i egne namespaces.
Videre er det ganske uoversiktelig logikk i `page` fortsatt. Spesielt rundt å velge en random dør, og reversering osv.
Jeg tror også CSSen bør ryddes litt opp i.

Tar gjerne tilbakemeldingner på datastrukturen til `load-ascii`!

