### PR TITLE
URLOG: samme URL får samme dør hver gang

### DIFF
--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -42,13 +42,6 @@
    :wall (slurp (str assets-dir "/wall.txt"))
    :doors (doall (map load-door (door-paths (str assets-dir "/doors/"))))})
 
-(comment
-  (logo->html (:logo load-ascii-assets))
-  (wall->html (:wall load-ascii-assets))
-  (let [door (first (:doors load-ascii-assets))]
-    (door+url->html door "example.com"))
-  (rand-nth (:doors load-ascii-assets)))
-
 (defn select-door [url doors]
   (let [seed (java.util.Random. (.hashCode url))]
     (when (seq doors)
@@ -57,6 +50,13 @@
 
 (def urlogfile-path "text/urlog/urls.edn")
 (def assets-dir "src/mikrobloggeriet/urlog_assets")
+
+(comment
+  (logo->html (:logo (load-ascii-assets assets-dir)))
+  (wall->html (:wall (load-ascii-assets assets-dir)))
+  (let [door (first (:doors (load-ascii-assets assets-dir)))]
+    (door+url->html door "example.com"))
+  (rand-nth (:doors (load-ascii-assets assets-dir))))
 
 (defn page [_req]
   (let [urlog-data (edn/read-string (slurp urlogfile-path))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -56,7 +56,12 @@
   (wall->html (:wall (load-ascii-assets assets-dir)))
   (let [door (first (:doors (load-ascii-assets assets-dir)))]
     (door+url->html door "example.com"))
-  (rand-nth (:doors (load-ascii-assets assets-dir))))
+  (rand-nth (:doors (load-ascii-assets assets-dir)))
+
+  ;; Samme resultat hver gang:
+  (let [doors (:doors (load-ascii-assets assets-dir))]
+    (select-door "example.com" doors))
+  )
 
 (defn page [_req]
   (let [urlog-data (edn/read-string (slurp urlogfile-path))

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -49,6 +49,12 @@
     (door+url->html door "example.com"))
   (rand-nth (:doors load-ascii-assets)))
 
+(defn select-door [url doors]
+  (let [seed (java.util.Random. (.hashCode url))]
+    (when (seq doors)
+      (let [index (.nextInt seed (count doors))]
+        (nth doors index)))))
+
 (def urlogfile-path "text/urlog/urls.edn")
 (def assets-dir "src/mikrobloggeriet/urlog_assets")
 

--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -81,8 +81,8 @@
         "Tilfeldige dører til internettsteder som kan være morsomme og/eller interessante å besøke en eller annen gang."]]
       [:div {:class :all-doors}
        (for [doc (reverse (:urlog/docs urlog-data))]
-         (let [door (rand-nth (:doors assets))
-               url (:urlog/url doc)]
+         (let [url (:urlog/url doc)
+               door (select-door url (:doors assets))]
            [:div {:class :wall :role :none}
             (wall->html (:wall assets))
             (door+url->html door url)

--- a/test/mikrobloggeriet/urlog_test.clj
+++ b/test/mikrobloggeriet/urlog_test.clj
@@ -1,0 +1,18 @@
+(ns mikrobloggeriet.urlog-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [mikrobloggeriet.urlog :as urlog]))
+
+(deftest select-door-test
+  (let [doors (:doors (urlog/load-ascii-assets urlog/assets-dir))
+        url-1 "https://mikrobloggeriet.no"
+        url-2 "https://iterate.no"
+        url-3 "https://wikipedia.org"]
+    (testing "when the URL is constant, the door is the same"
+      (is (= (urlog/select-door url-1 doors)
+             (urlog/select-door url-1 doors)
+             (urlog/select-door url-1 doors))))
+    (testing "for these three URLS, select-door shall give different URLs"
+      (is (not (= (urlog/select-door url-1 doors)
+                  (urlog/select-door url-2 doors)
+                  (urlog/select-door url-3 doors)))))))


### PR DESCRIPTION
## Hva

Dette er URLOG:

![image](https://github.com/iterate/mikrobloggeriet/assets/5285452/9ea65a38-3970-4d49-85df-6a15e5f5b36f)

I dag vises tilfeldig "dørbilde" for hver URL hver gang.

Denne PR-en gjør at vi får samme "dørbilde" for samme URL. Vi løser dette ved å lage et random seed fra URL-en, så plukke dør basert på den randomfunksjonen.

## Tanker og feedback-ønsker

Hvordan synes du det ser ut, Olav?

I Slack var `rand-nth-deterministic`, her finner du bare `select-door`. Synes det var bedre at urlog-navnerommet snakket om å velge dør enn å trekke n-te verdi deterministisk. Og jeg har skrevet en test :)