### PR TITLE
Router-eksperiment: reitit

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,6 +8,7 @@
   hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
   http-kit/http-kit {:mvn/version "2.7.0"}
   io.github.nextjournal/clerk {:mvn/version "0.15.957"}
+  metosin/reitit {:mvn/version "0.6.0"}
   org.babashka/cli {:mvn/version "0.7.53"}
   org.clojure/clojure {:mvn/version "1.11.1"}
   }

--- a/src/mikrobloggeriet/routes.clj
+++ b/src/mikrobloggeriet/routes.clj
@@ -1,0 +1,12 @@
+(ns mikrobloggeriet.routes)
+
+;; WORK IN PROGRESS
+;;
+;; Hvorfor?
+;; Les begrunnelse: https://garasjen.slack.com/archives/C05MH5RCLH3/p1706353191440179
+;;
+;; Hvordan?
+;;
+;; - Vi starter med å holde all ny kode i dette navnerommet.
+;;   Da kan vi slette alt hvis vi _ikke_ liker Reitit.
+;; - Og vi prøver oss på Oddmunds forslag om orakeltesting.

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -16,6 +16,8 @@
    [mikrobloggeriet.store :as store]
    [mikrobloggeriet.urlog :as urlog]
    [org.httpkit.server :as httpkit]
+   [reitit.core :as reitit]
+   [reitit.ring]
    [ring.middleware.cookies :as cookies]))
 
 (defn shared-html-header
@@ -333,7 +335,38 @@
 
 (comment
   (app {:uri "/olorm/olorm-1/", :request-method :get})
-  (app {:uri "/hops-info", :request-method :get}))
+  (app {:uri "/hops-info", :request-method :get})
+  :rcf)
+
+;; ## Ekspriment, bør vi bruke Reitit?
+;;
+;; Hvorfor?
+;;
+;; - Les begrunnelse og diskusjon i tråd:
+;;   https://garasjen.slack.com/archives/C05MH5RCLH3/p1706353191440179
+;;
+;; Hvordan?
+;;
+;; - Vi prøver oss på å implementere Reitit i prod ved siden av Compojure.
+;; - Og vi prøver å bruke orakeltesting for å sjekke hvordan dette går.
+;;   (forslag fra Oddmund i diskusjonstråden)
+
+(def ^{:experimental true}
+  app-experimental
+  (reitit.ring/ring-handler
+   (reitit.ring/router
+    [["/hops-info" {:get hops-info
+                    :name :mikrobloggeriet/hops-info}]])))
+
+(comment
+  (let [req {:request-method :get :uri "/hops-info"}]
+    (= (app req)
+       (app-experimental req)))
+  ;; => true
+
+  :rcf)
+
+;; ## REPL-grensesnitt
 
 (defonce server (atom nil))
 (def port 7223)


### PR DESCRIPTION
## Rasjonale

(etter torsdagens informasjon var jeg litt usikker på om det var smakfult å skrive om dette nå. Jeg valgte å skrive.)

### Jeg er interessert i å prøve Reitit til routing. I Reitit er router-tabellen en datastruktur.

Informasjon om Reitit: https://github.com/metosin/reitit

Her er en start:

```clojure
(require '[reitit.core :as reitit])

(def router
  (reitit/router
   [["/" :mikrobloggeriet/index]
    ["/olorm/" :mikrobloggeriet.olorm/index]
    ["/random-doc" :mikrobloggeriet/random-doc]]))
```

Det har reelle fordeler vi kunne brukt i dag:

- Vi kunne skrevet generisk logikk for å håndtere trailing / (feks at side redirecter til side/, eller at side/ redirecter til side)
- Vi får muligheten til å “slå opp hvilken URL en side har”
    - Docs: https://cljdoc.org/d/metosin/reitit/0.7.0-alpha7/doc/ring/reverse-routing
- Vi kunne skrevet generisk logikk for å generere subroutes for hver kohort
    - uten å hardkode at alle kohorter skal ha samme URL-struktur.
- Fordi router-tabellen mapper URL-er til nøkkelord med navnerom (feks :mikrobloggeriet/index), kan vi skrive enhetstester mot routeren, (uten å påvirke resten av applikasjonen)

### Hvordan?

Jeg ønsker å starte med å bytte ut dagens Compojure-routertabell med Reitit. Da ser vi fort hvordan vi opplever det, og får litt hands-on erfaring. Forbedringer (over) kan vente, det er steg 2.

### Hvem?

Jeg har mer lyst til å gjøre dette sammen med noen andre enn å kode det opp selv. Dette er en ikketriviell endring, vi snakker om å bytte ut kjernen av arkitekturen. Samtidig opplever jeg det som en ganske trygg endring. Vi sletter den gamle router-tabellen, bytter den ut med en reitit-tabell, og legger på routes én etter én. Så kan vi ta Mikrobloggeriet med ny router ut i et testmiljø for å se om det funker.

Dette hadde også vært kult å teste med Playwright. Sjekke at alle routes i router-tabellen gir samme responskode (200) på alle GET-routes, kanskje også sjekke at payload er lik. En sånn test vil være supernyttig senere, da har vi plutselig et Playwright-oppsett vi kan bruke i CI. (enda en fordel med Reitit er at router-tabellen er data, så vi kan iterere over router-tabellen for å finne “startpunkter”.

Interessert?

### Hva hvis vi ikke liker Reitit?

Da bytter vi tilbake.

### Orakeltesting

Jeg har innført et endepunkt `/app12-compat-report` der man kan se hvilke responser som gir samme respons for ny og for gammel router.

Per nå ser denne sånn ut, kun `/hops-info` er flyttet over:

![image](https://github.com/iterate/mikrobloggeriet/assets/5285452/7d439344-94e7-4748-ab76-8904a2e1c568)