### PR TITLE
Flytt dokument opprettet-logikk til doc-meta

### DIFF
--- a/src/mikrobloggeriet/doc_meta.clj
+++ b/src/mikrobloggeriet/doc_meta.clj
@@ -4,5 +4,11 @@
   (= :draft
      (:doc/state doc+meta)))
 
+(defn created [doc+meta]
+  (:doc/created doc+meta))
+
+(defn created-instant [doc+meta]
+  (.toInstant (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (created doc+meta))))
+
 (comment
   (draft? {:doc/state :draft}))

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -11,6 +11,7 @@
    [mikrobloggeriet.cache :as cache]
    [mikrobloggeriet.cohort :as cohort]
    [mikrobloggeriet.doc :as doc]
+   [mikrobloggeriet.doc-meta :as doc-meta]
    [mikrobloggeriet.http :as http]
    [mikrobloggeriet.pandoc :as pandoc]
    [mikrobloggeriet.store :as store]
@@ -64,20 +65,11 @@
                           :title (pandoc/infer-title pandoc)}))
                      identity))
 
-(defn read-created-date [file-path]
-  (let [content (slurp file-path)
-        data (edn/read-string content)]
-    (:doc/created data)))
-
-(defn ->java-time-instant [date]
-  (.toInstant
-   (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") (str date))))
-
 (defn cohort-rss-section [cohort]
   (for [doc (store/docs cohort)]
     {:title (doc/slug doc)
      :link (str "https://mikrobloggeriet.no" (store/doc-href cohort doc))
-     :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
+     :pubDate (doc-meta/created-instant (store/load-meta cohort doc))
      :category (cohort/slug cohort)
      :description (doc/slug doc)
      :guid (doc/slug doc)
@@ -95,6 +87,11 @@
                             (cohort-rss-section store/jals)
                             (cohort-rss-section store/oj)
                             (cohort-rss-section store/genai))}))
+
+(comment
+  (def rss1 (rss-feed))
+  (spit "rss.xml" (:body rss1))
+  )
 
 (defn cohort-doc-table [req cohort]
   (page/html5


### PR DESCRIPTION
## Hva er dette?

Denne endringen er et type grep jeg veldig ofte gjør for å gjøre Clojure-kode lettere å jobbe med: jeg jobber for å få navn til å gi mening i navnerommet sitt. Jeg syntes ikke `mikrobloggeriet.serve/read-created-date` passet helt inn, _hva_ slags enititet snakket vi om her? Navnerommene `mikrobloggeriet.doc` og `mikrobloggeriet.doc-meta` er ment til å snakke om dokumenter og metadata for dokumenter.

## Hvorfor review?

Jeg har satt mange på reviewers her, det er fordi jeg synes denne endringen er interessant når man jobber med Clojure.

@JohanMartinEJohnsen og @jraregris: dere jobbet med RSS-logikken orginalt.

Hører gjerne hva dere synes før vi prodsetter!

## Er denne endringen trygg?

Ja, jeg er komfortabel med å gå prod nå. Jeg har sjekket at ny og gammel kode gir samme svar med REPL.

Dog: hvis vi hadde hatt noen form for tester for RSS-logikken, hadde den vært tryggere å endre.