### PR TITLE
PostgreSQL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'openjdk'
+          distribution: 'temurin'
           java-version: '18'
 
       - name: Install clojure tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,7 @@ jobs:
 
       - name: Download test deps
         run: clojure -A:test -e :test-deps-downloaded
+      - name: print java version
+        run: java -version
       - name: Run tests
         run: clojure -M:run-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,15 @@ jobs:
 
       - name: Check out repository code
         uses: actions/checkout@v3
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'openjdk'
+          java-version: '18'
+
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@9.4
+        uses: DeLaGuardo/setup-clojure@12.4
         with:
           cli: latest
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
   babashka/process {:mvn/version "0.5.21"}
   cheshire/cheshire {:mvn/version "5.12.0"}
   clj-rss/clj-rss {:mvn/version "0.4.0"}
+  com.github.igrishaev/pg2-core {:mvn/version "0.1.2"}
   compojure/compojure {:mvn/version "1.7.0"}
   hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
   http-kit/http-kit {:mvn/version "2.7.0"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Connect to local pg with psql:
   #
-  #     $ psql -d "host=localhost port=5432 dbname=mikrobloggeriet user=mikrobloggeriet"
+  #     $ psql -d "postgresql://localhost:5432/mikrobloggeriet?user=mikrobloggeriet&password=mikrobloggeriet"
   db:
     image: postgres:13
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 services:
+  # Connect to local pg with psql:
+  #
+  #     $ psql -d "host=localhost port=5432 dbname=mikrobloggeriet user=mikrobloggeriet"
   db:
     image: postgres:13
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,5 @@ services:
     command:
       - "-c"
       - "fsync=off"
-    volumes:
-      - "postgress-logs:/var/log/postgresql/"
     ports:
       - 5432:5432
-    networks:
-      - proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Connect to local pg with psql:
   #
-  #     $ psql -d "postgresql://localhost:5432/mikrobloggeriet?user=mikrobloggeriet&password=mikrobloggeriet"
+  #     $ psql -d "postgresql://localhost:7574/mikrobloggeriet?user=mikrobloggeriet&password=mikrobloggeriet"
   db:
     image: postgres:13
     environment:
@@ -12,4 +12,4 @@ services:
       - "-c"
       - "fsync=off"
     ports:
-      - 5432:5432
+      - 7574:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: mikrobloggeriet
+      POSTGRES_USER: mikrobloggeriet
+      POSTGRES_DB: mikrobloggeriet
+    command:
+      - "-c"
+      - "fsync=off"
+    volumes:
+      - "postgress-logs:/var/log/postgresql/"
+    ports:
+      - 5432:5432
+    networks:
+      - proxy

--- a/draft/mikrobloggeriet/teodor/db.clj
+++ b/draft/mikrobloggeriet/teodor/db.clj
@@ -1,0 +1,6 @@
+(ns mikrobloggeriet.teodor.db)
+
+;; skal vi ha tilstand?
+;; Det har fordeler :)
+
+;; la oss prøve litt.

--- a/draft/mikrobloggeriet/teodor/db.clj
+++ b/draft/mikrobloggeriet/teodor/db.clj
@@ -1,6 +1,16 @@
-(ns mikrobloggeriet.teodor.db)
+;; # Database for Mikrobloggeriet?
+
+(ns mikrobloggeriet.teodor.db
+  )
 
 ;; skal vi ha tilstand?
 ;; Det har fordeler :)
 
 ;; la oss prøve litt.
+
+;; Vi går med https://github.com/igrishaev/pg2.
+;; Hvorfor?
+;;
+;; - next.jdbc er flott
+;; - men jeg har lyst til å kunne jobbe mot /rå postgres/.
+;;   Ikke bare gjøre "generell SQL".

--- a/draft/mikrobloggeriet/teodor/db.clj
+++ b/draft/mikrobloggeriet/teodor/db.clj
@@ -2,9 +2,8 @@
 
 (ns mikrobloggeriet.teodor.db
   (:require
+   [mikrobloggeriet.config :as config]
    [pg.core :as pg]))
-
-
 
 ;; skal vi ha tilstand?
 ;; Det har fordeler :)
@@ -18,17 +17,13 @@
 ;; - men jeg har lyst til å kunne jobbe mot /rå postgres/.
 ;;   Ikke bare gjøre "generell SQL".
 
-#_
-(def
-  "Does not yet work!"
-  config
-  {:host "127.0.0.1"
-   :port 10140
-   :user "test"
-   :password "test"
-   :database "test"})
+(def config
+  {:host "localhost"
+   :port config/pg-port
+   :user "mikrobloggeriet"
+   :password "mikrobloggeriet"
+   :database "mikrobloggeriet"})
 
-#_
 (defonce conn (pg/connect config))
 
 (comment

--- a/draft/mikrobloggeriet/teodor/db.clj
+++ b/draft/mikrobloggeriet/teodor/db.clj
@@ -1,7 +1,10 @@
 ;; # Database for Mikrobloggeriet?
 
 (ns mikrobloggeriet.teodor.db
-  )
+  (:require
+   [pg.core :as pg]))
+
+
 
 ;; skal vi ha tilstand?
 ;; Det har fordeler :)
@@ -14,3 +17,21 @@
 ;; - next.jdbc er flott
 ;; - men jeg har lyst til å kunne jobbe mot /rå postgres/.
 ;;   Ikke bare gjøre "generell SQL".
+
+#_
+(def
+  "Does not yet work!"
+  config
+  {:host "127.0.0.1"
+   :port 10140
+   :user "test"
+   :password "test"
+   :database "test"})
+
+#_
+(defonce conn (pg/connect config))
+
+(comment
+
+
+  )

--- a/draft/mikrobloggeriet/teodor/db.clj
+++ b/draft/mikrobloggeriet/teodor/db.clj
@@ -26,6 +26,8 @@
 
 (defonce conn (pg/connect config))
 
+(pg/query conn "select 1 as one")
+
 (comment
 
 

--- a/draft/mikrobloggeriet/teodor/try_db.clj
+++ b/draft/mikrobloggeriet/teodor/try_db.clj
@@ -27,8 +27,3 @@
 (defonce conn (pg/connect config))
 
 (pg/query conn "select 1 as one")
-
-(comment
-
-
-  )

--- a/draft/mikrobloggeriet/teodor/try_db.clj
+++ b/draft/mikrobloggeriet/teodor/try_db.clj
@@ -1,6 +1,6 @@
 ;; # Database for Mikrobloggeriet?
 
-(ns mikrobloggeriet.teodor.db
+(ns mikrobloggeriet.teodor.try-db
   (:require
    [mikrobloggeriet.config :as config]
    [pg.core :as pg]))

--- a/iterapp.toml
+++ b/iterapp.toml
@@ -1,3 +1,5 @@
 default_environment = "prod"
 port = 7223
 domains = ["mikrobloggeriet.no"]
+
+[postgresql]

--- a/src/mikrobloggeriet/config.clj
+++ b/src/mikrobloggeriet/config.clj
@@ -1,0 +1,5 @@
+(ns mikrobloggeriet.config)
+
+(def http-server-port)
+(def clerk-port)
+(def pg-port)

--- a/src/mikrobloggeriet/config.clj
+++ b/src/mikrobloggeriet/config.clj
@@ -1,5 +1,5 @@
 (ns mikrobloggeriet.config)
 
 (def http-server-port)
-(def clerk-port)
+(def clerk-port 7743)
 (def pg-port)

--- a/src/mikrobloggeriet/config.clj
+++ b/src/mikrobloggeriet/config.clj
@@ -2,4 +2,4 @@
 
 (def http-server-port 7223)
 (def clerk-port 7743)
-(def pg-port)
+(def pg-port 7574)

--- a/src/mikrobloggeriet/config.clj
+++ b/src/mikrobloggeriet/config.clj
@@ -1,5 +1,5 @@
 (ns mikrobloggeriet.config)
 
-(def http-server-port)
+(def http-server-port 7223)
 (def clerk-port 7743)
 (def pg-port)

--- a/src/mikrobloggeriet/db.clj
+++ b/src/mikrobloggeriet/db.clj
@@ -1,0 +1,40 @@
+(ns mikrobloggeriet.db
+  (:require
+   [mikrobloggeriet.config :as config]))
+
+(def dev-config
+  {:host "localhost"
+   :port config/pg-port
+   :user "mikrobloggeriet"
+   :password "mikrobloggeriet"
+   :database "mikrobloggeriet"})
+
+;; igrishaev/pg2 config docs: https://github.com/igrishaev/pg2?tab=readme-ov-file#connecting-to-the-server
+;;
+;; HOPS PG env vars: https://hops-doc.app.iterate.no/reference/environment_variables.html
+
+(def hops->pg2
+  {"PGDATABASE" :database
+   "PGHOST" :host
+   "PGPASSWORD" :password
+   "PGPORT" :port
+   "PGUSER" :user})
+
+(def pg2->hops
+  (into {}
+        (for [[k v] hops->pg2]
+          [v k])))
+
+(defn hops-config [env]
+  (into {}
+        (for [[envvar confkey] hops->pg2]
+          [confkey (get env envvar)])))
+
+(comment
+  (hops-config {"PGDATABASE" "mikrobloggeriet"
+                "PGHOST" "localhost"
+                "PGPASSWORD" "mikrobloggeriet"
+                "PGPORT" config/pg-port
+                "PGUSER" "mikrobloggeriet"})
+
+  (System/getenv))

--- a/src/mikrobloggeriet/db.clj
+++ b/src/mikrobloggeriet/db.clj
@@ -1,6 +1,8 @@
 (ns mikrobloggeriet.db
   (:require
-   [mikrobloggeriet.config :as config]))
+   [mikrobloggeriet.config :as config]
+   [pg.core :as pg]
+   [clojure.pprint :refer [pprint]]))
 
 (def dev-config
   {:host "localhost"
@@ -38,3 +40,15 @@
                 "PGUSER" "mikrobloggeriet"})
 
   (System/getenv))
+
+(defn try-db-stuff [_req]
+  ;; function to try running database stuff to see if we can connect successfully.
+  (let [pg-config (hops-config (System/getenv))
+        conn (pg/connect pg-config)
+        fourty-two (pg/query conn "select 42 as fourty_two")
+        response
+        {:status 200
+         :headers {"Content-Type" "text/plain"}
+         :body (with-out-str (pprint fourty-two))}]
+    (pg/close conn)
+    response))

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -368,7 +368,6 @@
 ;; ## REPL-grensesnitt
 
 (defonce server (atom nil))
-(def port config/http-server-port)
 (defn stop-server [stop-fn] (when stop-fn (stop-fn)) nil)
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn stop! [] (swap! server stop-server))
@@ -378,10 +377,10 @@
   (swap! server
          (fn [old-server]
            (stop-server old-server)
-           (println (str "mikroboggeriet.serve running: http://localhost:" port))
+           (println (str "mikroboggeriet.serve running: http://localhost:" config/http-server-port))
            (httpkit/run-server (fn [req]
                                  ((app) req))
-                               {:port port}))))
+                               {:port config/http-server-port}))))
 
 (comment
   ((app) {:uri "/hops-info", :request-method :get})
@@ -392,6 +391,6 @@
   (swap! server
          (fn [old-server]
            (stop-server old-server)
-           (println (str "mikroboggeriet.serve running: http://localhost:" port))
+           (println (str "mikroboggeriet.serve running: http://localhost:" config/http-server-port))
            (httpkit/run-server (app)
-                               {:port port}))))
+                               {:port config/http-server-port}))))

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -17,7 +17,8 @@
    [org.httpkit.server :as httpkit]
    [reitit.core :as reitit]
    [reitit.ring]
-   [ring.middleware.cookies :as cookies]))
+   [ring.middleware.cookies :as cookies]
+   [mikrobloggeriet.config :as config]))
 
 (declare app)
 (declare url-for)
@@ -367,7 +368,7 @@
 ;; ## REPL-grensesnitt
 
 (defonce server (atom nil))
-(def port 7223)
+(def port config/http-server-port)
 (defn stop-server [stop-fn] (when stop-fn (stop-fn)) nil)
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn stop! [] (swap! server stop-server))

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -9,6 +9,8 @@
    [mikrobloggeriet.cache :as cache]
    [mikrobloggeriet.cohort :as cohort]
    [mikrobloggeriet.cohort.urlog :as cohort.urlog]
+   [mikrobloggeriet.config :as config]
+   [mikrobloggeriet.db :as db]
    [mikrobloggeriet.doc :as doc]
    [mikrobloggeriet.doc-meta :as doc-meta]
    [mikrobloggeriet.http :as http]
@@ -17,8 +19,7 @@
    [org.httpkit.server :as httpkit]
    [reitit.core :as reitit]
    [reitit.ring]
-   [ring.middleware.cookies :as cookies]
-   [mikrobloggeriet.config :as config]))
+   [ring.middleware.cookies :as cookies]))
 
 (declare app)
 (declare url-for)
@@ -348,7 +349,12 @@
 
      ;; Go to a random document
      [["/random-doc" {:get random-doc
-                      :name :mikrobloggeriet/random-doc}]]))
+                      :name :mikrobloggeriet/random-doc}]]
+
+     ;; Try if the DB works
+     [["/try-db-stuff" {:get db/try-db-stuff
+                        :name :mikrobloggeriet/try-db-stuff}]]
+     ))
    (reitit.ring/redirect-trailing-slash-handler)))
 
 (defn url-for

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,7 +1,8 @@
 (ns user
   (:require
+   [babashka.fs :as fs]
    [clojure.string :as str]
-   [babashka.fs :as fs]))
+   [mikrobloggeriet.config :as config]))
 
 ;; Convenience functions when you start a REPL. The default user namespace is
 ;; always 'user. I'm putting functions here to make it easy to start the server
@@ -69,7 +70,7 @@
   ([] (clerk-start! {}))
   ([opts]
    (let [clerk-serve (requiring-resolve 'nextjournal.clerk/serve!)
-         clerk-port 7743
+         clerk-port config/clerk-port
          opts (merge {:browse? true :port clerk-port} opts)]
      (clerk-serve opts))))
 

--- a/src/user.clj
+++ b/src/user.clj
@@ -93,7 +93,7 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn clerk-start-watch! []
   (let [clerk-serve (requiring-resolve 'nextjournal.clerk/serve!)
-        clerk-port 7743]
+        clerk-port config/clerk-port]
     (clerk-serve {:browse? true
                   :port clerk-port
                   :watch-paths ["src" "test" "draft"]})))


### PR DESCRIPTION
### Motivasjon

I dag er hele Mikrobloggeriet et _tilstandsløst system_. På engelsk, _a stateless system_. Det gjør Mikrobloggeriet lett å jobbe med, vi har kun kode og data.

Men! Det setter begrensninger. Vi kan for eksempel ikke samle data om trafikk. Eller styre oppførselen til Mikrobloggeriet dynamisk imens Mikrobloggeriet kjører.

Mikrobloggeriet kjører på HOPS. Hops har god støtte for PostgreSQL. Så kanskje vi skal bruke PostgreSQL!

### Denne PR-en

1. Setter opp PostgreSQL lokalt med Docker Compose
2. Gir noe eksempelkode med et PostgreSQL-bibliotek.

### igrishaev/pg2 eller seancorfield/next-jdbc?

Her ser jeg på det svært nye og forholdsvis uprøvde bibioteket https://github.com/igrishaev/pg2. `pg2` er et rent PostgreSQL-bibliotek som gir oss god tilgang til rene PostgreSQL-features.

Et annet alterntiv er https://github.com/seancorfield/next-jdbc. `next-jdbc` er veletablert, mye brukt og godt dokumentert. `next-jdbc` har samme API for _mange_ SQL-databaser.

Per nå er jeg mest interessert i `pg2` - fordi det gir en bedre mulighet til å lære PostgreSQL enn `next.jdbc`.

### `mikrobloggeriet.config`

Jeg har også innført et nytt navnerom: `mikrobloggeriet.config`. Her har vi foreløpig kun informasjon om hvilke porter vi kjører på. Jeg trakk dette ut fordi jeg ikke ville hardkode porter mange steder, og måtte bestemme en port vi kunne kjøre PostgreSQL på.

Jeg har trukket tilfeldige tall mellom 7000 og 7999 som portnumre. Tilfeldige tall for å unngå kollisjoner med andre ting man kanskje kjører lokalt.

### Andre databaser

PostgreSQL er en solid SQL-database.

Clojure-økosystemet har i tillegg to datalog-databaser å tilby:

- Datomic (https://www.datomic.com/)
- XTDB (https://xtdb.com/)

Begge kan kjøre _hosted_ oppå PostgreSQL. Det betyr at vi bruker Datomic eller XT, men dataen lagres i en PostgreSQL-database.

Jeg ønsker å starte med rå PostgreSQL for å få litt følelsen med PG før vi gjør noe mer komplisert. PostgreSQL er en fin ting å kunne.