### PR TITLE
System for SQL-migrasjoner

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,7 @@
   metosin/reitit {:mvn/version "0.6.0"}
   org.babashka/cli {:mvn/version "0.8.55"}
   org.clojure/clojure {:mvn/version "1.11.1"}
+  ragtime/ragtime {:mvn/version "0.8.1"}
   }
  :aliases
  {:dev

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -2,7 +2,8 @@
   "Database migrations on Mikrobloggeriet"
   (:require
    [mikrobloggeriet.repl :as repl]
-   [pg.core :as pg]))
+   [pg.core :as pg]
+   [nextjournal.clerk :as clerk]))
 
 (defn ensure-migrations-table!
   [conn]
@@ -19,3 +20,17 @@
   )
 
 (pg/query dev-conn "select 123 as num")
+
+(pg/query dev-conn "create table if not exists foo(id integer not null, description text)")
+
+(comment
+  (pg/execute dev-conn "insert into foo(id, description) values ($1, $2)" {:params [1 "first"]})
+
+
+  )
+
+^::clerk/no-cache
+(clerk/table (pg/query dev-conn "select * from foo"))
+
+^{:nextjournal.clerk/visibility {:code :hide}}
+(clerk/html [:div {:style {:height "50vh"}}])

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -50,7 +50,6 @@ create table if not exists migrations(
     (run-up! [_ db] (pg/query (.conn db) up))
     (run-down! [_ db] (pg/query (.conn db) down))))
 
-
 (def all-migrations
   [(sql-migration {:id "add-foo-table"
                    :up "create table foo (id integer primary key, description text)"

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -50,6 +50,7 @@ create table if not exists migrations(
     (run-down! [_ db] (pg/query (.conn db) down))))
 
 (def all-migrations
+  "All migrations that have been used in the current session."
   [(sql-migration {:id "add-foo-table"
                    :up "create table foo (id integer primary key, description text)"
                    :down "create table foo (id integer primary key, description text)"})
@@ -60,6 +61,9 @@ create table if not exists migrations(
 (def migration-index (ragtime/into-index all-migrations))
 
 (def migrations
+  "Represent the current desired database schema state.
+
+  Should be equal to `all-migrations` when code is merged to master."
   [])
 
 (defn migrate-dev!

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -1,5 +1,8 @@
 (ns mikrobloggeriet.db.migrate
-  "Database migrations on Mikrobloggeriet")
+  "Database migrations on Mikrobloggeriet"
+  (:require
+   [mikrobloggeriet.repl :as repl]
+   [pg.core :as pg]))
 
 (defn ensure-migrations-table!
   [conn]
@@ -7,3 +10,12 @@
 
 (defn delete-migrations-table!
   [conn])
+
+(defonce dev-conn (:mikrobloggeriet.system/db @repl/state))
+
+(comment
+  (alter-var-root #'dev-conn (constantly (:mikrobloggeriet.system/db @repl/state)))
+
+  )
+
+(pg/query dev-conn "select 123 as num")

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -5,6 +5,7 @@
    [nextjournal.clerk :as clerk]
    [pg.core :as pg]
    [ragtime.core :as ragtime]
+   [ragtime.strategy]
    [ragtime.protocols]))
 
 (defn ensure-migrations-table!
@@ -20,9 +21,9 @@ create table if not exists migrations(
   (assert (not (System/getenv "HOPS_ENV")) "Do NOT drop the migrations table in production.")
   (pg/query conn "drop table migrations"))
 
-(defonce dev-conn (:mikrobloggeriet.system/db @repl/state))
 
 (comment
+  (defonce dev-conn (:mikrobloggeriet.system/db @repl/state))
   (alter-var-root #'dev-conn (constantly (:mikrobloggeriet.system/db @repl/state)))
   (ensure-migrations-table! dev-conn)
   (dangerously-delete-migrations-table!! dev-conn)
@@ -41,23 +42,48 @@ create table if not exists migrations(
     (->> (pg/query conn "select id from migrations")
          (map :id))))
 
-(def migrations [(reify ragtime.protocols/Migration
-                   (id [_] "add-foo-table")
-                   (run-up! [_ db] (pg/query (.conn db) "create table foo (id integer primary key, description text)"))
-                   (run-down! [_ db] (pg/query (.conn db) "create table foo (id integer primary key, description text)")))])
+(defn sql-migration [{:keys [id up down]}]
+  (reify ragtime.protocols/Migration
+    (id [_] id)
+    (run-up! [_ db] (pg/query (.conn db) up))
+    (run-down! [_ db] (pg/query (.conn db) down))))
+
+
+(def all-migrations
+  [(sql-migration {:id "add-foo-table"
+                   :up "create table foo (id integer primary key, description text)"
+                   :down "create table foo (id integer primary key, description text)"})
+   (sql-migration {:id "add-bar-table"
+                   :up "create table bar (id integer)"
+                   :down "drop table bar"})])
+
+(def migration-index (ragtime/into-index all-migrations))
+
+(def migrations
+  [(sql-migration {:id "add-foo-table"
+                   :up "create table foo (id integer primary key, description text)"
+                   :down "create table foo (id integer primary key, description text)"})])
 
 (comment
-  (ragtime/migrate (PgDatabase. dev-conn)
-                   (first migrations))
+  (defonce dev-conn (:mikrobloggeriet.system/db @repl/state))
 
-  (let [index (ragtime/into-index migrations)]
-    (ragtime/applied-migrations (PgDatabase. dev-conn) index))
+  ;; in production, migrate with ragtime.strategy/raise-error
+  (ragtime/migrate-all (PgDatabase. dev-conn)
+                       migration-index
+                       migrations
+                       {:strategy ragtime.strategy/raise-error})
 
+  ;; in development, migrate with ragtime.strategy/rebase
+  (ragtime/migrate-all (PgDatabase. dev-conn)
+                       migration-index
+                       migrations
+                       {:strategy ragtime.strategy/rebase})
 
+  ^::clerk/no-cache
+  (clerk/table
+   (pg/query dev-conn "select * from migrations"))
   )
 
-^::clerk/no-cache
-(pg/query dev-conn "select * from migrations")
 
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (clerk/html [:div {:style {:height "50vh"}}])

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -7,15 +7,23 @@
 
 (defn ensure-migrations-table!
   [conn]
-  )
+  (pg/query conn
+            "create table if not exists migrations(id text primary key)"))
 
 (defn delete-migrations-table!
-  [conn])
+  [conn]
+  (assert (not (System/getenv "HOPS_ENV"))
+          "Do NOT run this in production!")
+  (pg/query conn
+            "drop table migrations"))
 
 (defonce dev-conn (:mikrobloggeriet.system/db @repl/state))
 
 (comment
   (alter-var-root #'dev-conn (constantly (:mikrobloggeriet.system/db @repl/state)))
+
+  (ensure-migrations-table! dev-conn)
+  (delete-migrations-table! dev-conn)
 
   )
 
@@ -26,11 +34,11 @@
 (comment
   (pg/execute dev-conn "insert into foo(id, description) values ($1, $2)" {:params [1 "first"]})
 
-
   )
 
 ^::clerk/no-cache
-(clerk/table (pg/query dev-conn "select * from foo"))
+(clerk/caption "foo table"
+               (clerk/table (pg/query dev-conn "select * from foo")))
 
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (clerk/html [:div {:style {:height "50vh"}}])

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -32,7 +32,8 @@ create table if not exists migrations(
 
   (pg/query dev-conn "select * from migrations")
 
-  )
+  :rcf)
+
 
 (defrecord PgDatabase [conn]
   ragtime.protocols/DataStore

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -62,9 +62,7 @@ create table if not exists migrations(
 (def migration-index (ragtime/into-index all-migrations))
 
 (def migrations
-  [(sql-migration {:id "add-foo-table"
-                   :up "create table foo (id integer primary key, description text)"
-                   :down "create table foo (id integer primary key, description text)"})])
+  [])
 
 (defn migrate-dev!
   "Migrate and rebase if necessary."

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -2,7 +2,6 @@
   "Database migrations on Mikrobloggeriet"
   (:require
    [mikrobloggeriet.repl :as repl]
-   [nextjournal.clerk :as clerk]
    [pg.core :as pg]
    [ragtime.core :as ragtime]
    [ragtime.strategy]
@@ -90,6 +89,3 @@ create table if not exists migrations(
   (migrate-dev! (PgDatabase. dev-conn))
 
   :rcf)
-
-^{:nextjournal.clerk/visibility {:code :hide}}
-(clerk/html [:div {:style {:height "50vh"}}])

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -1,0 +1,9 @@
+(ns mikrobloggeriet.db.migrate
+  "Database migrations on Mikrobloggeriet")
+
+(defn ensure-migrations-table!
+  [conn]
+  )
+
+(defn delete-migrations-table!
+  [conn])

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -19,6 +19,10 @@ create table if not exists migrations(
   (not (System/getenv "HOPS_ENV")))
 
 (defn dangerously-delete-migrations-table!!
+  "Delete the migrations table.
+
+  Should `never` be used in production. Deleting the migrations table is useful
+  _only_ when working on the migrations system."
   [conn]
   (assert (not-prod?) "Do NOT drop the migrations table in production.")
   (pg/query conn "drop table migrations"))

--- a/src/mikrobloggeriet/db/migrate.clj
+++ b/src/mikrobloggeriet/db/migrate.clj
@@ -34,7 +34,6 @@ create table if not exists migrations(
 
   :rcf)
 
-
 (defrecord PgDatabase [conn]
   ragtime.protocols/DataStore
   (add-migration-id [_ id]

--- a/src/mikrobloggeriet/repl.clj
+++ b/src/mikrobloggeriet/repl.clj
@@ -1,0 +1,3 @@
+(ns mikrobloggeriet.repl)
+
+(defonce state (atom nil))

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -285,7 +285,7 @@
 
   For example as an opt-in experience when working on HTML / Clojure"
   [_req]
-  (let [last-modified (last-modified-file "." "**/*.{js,css,html,clj,md,edn}")]
+  (let [last-modified (last-modified-file "." "**/*.{clj,css,edn,html,js,md}")]
     {:status 200
      :headers {"Content-Type" "text/plain"}
      :body (str (fs/last-modified-time last-modified) "\n")}))

--- a/src/mikrobloggeriet/system.clj
+++ b/src/mikrobloggeriet/system.clj
@@ -61,6 +61,7 @@
 
 (defmethod ig/init-key ::db-migrate
   [_ {:keys [db]}]
+  (db.migrate/ensure-migrations-table! db)
   (db.migrate/migrate! db))
 
 (defmethod ig/init-key ::app

--- a/src/user.clj
+++ b/src/user.clj
@@ -3,6 +3,7 @@
    [babashka.fs :as fs]
    [clojure.string :as str]
    [mikrobloggeriet.config :as config]
+   [mikrobloggeriet.repl :as repl]
    [integrant.core :as ig]))
 
 ;; Convenience functions when you start a REPL. The default user namespace is
@@ -31,8 +32,6 @@
 ;; code! `require-resolve` is a dynamic require, and will crash runtime rather
 ;; than compile-time if there are import errors.
 
-(defonce system (atom nil))
-
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn start!
   ([]
@@ -45,12 +44,12 @@
      (require 'mikrobloggeriet.system)
      ;; Try start with db first.
      (try
-       (reset! system (integrant.core/init (dev+db)))
+       (reset! repl/state (integrant.core/init (dev+db)))
        (println "Started Mikrobloggeriet with database.")
        (catch Exception _e
            ;; error starting with db
            ;; try again without db!
-           (reset! system (integrant.core/init (dev)))
+           (reset! repl/state (integrant.core/init (dev)))
            (println "Started Mikrobloggeriet without database.")))
      (let [browser (System/getenv "BROWSER")
            url (str "http://localhost:" config/http-server-port)]
@@ -74,9 +73,9 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn stop! []
-  (when-let [sys @system]
+  (when-let [sys @repl/state]
     (ig/halt! sys)
-    (reset! system nil)))
+    (reset! repl/state nil)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn clerk-start!


### PR DESCRIPTION
## Designspørsmål

Motivasjon for å gjøre dette, og grovt hvordan vi _kan_ gjøre det.

### Motivasjon

Nå som vi har PostgreSQL-støtte må vi ha en måte å jobbe med SQL-skjemaer. Det kalles _migrasjoner_.

Jeg vet om to migrering-biblioteker:

- https://github.com/weavejester/ragtime
- https://github.com/yogthos/migratus

### Alternativ: Ragtime

Skrevet av James Reeves (også skrevet Ring, Compojure og Hiccup). Litt lavnivå, litt "samle sammen det du trenger". Litt lite dokumentasjon.

Det følger med et lavnivå migrerings-grensesnitt _som ikke er koblet på SQL_. Som er litt kult.

### Alternativ: Migratus

Skrevet av Dmitri Sotnikov, som også har skrevet en bok om web-utvikling i Clojure: https://pragprog.com/titles/dswdcloj3/web-development-with-clojure-third-edition/

### Ragtime eller Migratus, hva er best for oss?

Vi har i dag postgresql-støtte med https://github.com/igrishaev/pg2. Migratus funker kun med jdbc (og kanskje jdbc.next). Så jeg tror ganske enkelt Migratus ikke løser noen problemer for oss.

Så jeg prøver med Ragtime.

### Systemdesign: migrasjoner på Mikrobloggeriet

Jeg ser for meg:

* Vi kjører migrasjoner på app-oppstart. Etter vi har fått en database-connection, før vi starter HTTP-serveren.
* Vi skriver migrasjoner med opp- og ned-kommandoer (så vi kan migrere fram og tilbake)
* Vi bruker Ragtime, men mapper over til igrishaev/pg2 selv.

## Beskrivelse av implementasjon

Jeg gikk for Ragtime. Jeg synes det var midt i blinken. At Ragtime er database-agnostisk viste seg å være noe jeg likte. Det krevde lite kode å sette opp, og nå slipper vi magi vi ikke har kontroll over.

### Systemdesign

- Logikk for migrering er i det nye navnerommet `mikrobloggeriet.db.migrate`.
- Jeg har flyttet tilstanden for det kjørende systemet til `mikrobloggeriet.repl/state`. Tidligere lå denne i `user`, og før det lå den i `mikrobloggeriet.serve`. Ved å flytte den til `mikrobloggeriet.repl/state` kan vi referere _til den_ fra andre steder, feks `mikrobloggeriet.db.migrate`.
- Til lokal utvikling kan man bruke `mikrobloggeriet.db.migrate/migrate-dev!`. `migrate-dev!` kan kun kjøres lokalt, men støtter å rulle både framover og bakover. I produksjon ruller vi ikke bakover, fordi da risikerer vi å miste data. I lokal utvikling er dette en fin mulighet å kunne ha mens man jobber med database-skjemaer.

### Migreringsstrategi

1. Ved oppstart gjør vi en migrering, så lenge vi kjører med en database. Migrering på oppstart migrerer _kun framover_.
2. For å jobbe med skjemastruktur lokalt kan vi migrere fram og tilbake med funksjonen `mikrobloggeriet.db.migrate/migrate-dev!`. Denne krasjer hvis den kjøres på hops (krever at `HOPS_ENV` ikke er satt).