### PR TITLE
Alternative markdown parser: `nextjournal/markdown`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
   integrant/integrant {:mvn/version "0.8.1"}
   integrant/repl {:mvn/version "0.3.3"}
   io.github.nextjournal/clerk {:mvn/version "0.15.957"}
+  io.github.nextjournal/markdown {:mvn/version "0.5.148"}
   metosin/malli {:mvn/version "0.14.0"}
   metosin/reitit {:mvn/version "0.6.0"}
   org.babashka/cli {:mvn/version "0.8.57"}

--- a/draft/mikrobloggeriet/teodor/journal.org
+++ b/draft/mikrobloggeriet/teodor/journal.org
@@ -1,0 +1,12 @@
+#+title: Journal
+
+* 2024-03-16
+** Unødvendig fleksibilitet er dårlig
+I dag har vi:
+
+- Multimetoder for å støtte forskjellige kohorter
+- Pandoc-bruk for å støtte flere inputformater.
+
+Bør vi fjerne den fleksibliteten?
+Og hvis vi fjerner, hva skjer da?
+** Eksperiment: sammenlikne Pandoc nesxtjournal/markdown for konvertering av Markdown til HTML

--- a/draft/mikrobloggeriet/teodor/markdown_compare.clj
+++ b/draft/mikrobloggeriet/teodor/markdown_compare.clj
@@ -63,3 +63,13 @@
 (clerk/html (convert-nextjournal "Dette er alt—la oss gå videre!"))
 
 ;; mmmmm.
+
+;; hvordan representerer pandoc em-dasher?
+
+(pandoc/from-markdown "Dette er alt---la oss gå videre!")
+
+;; ikke noe spesielt type element nei, bare en rå —.
+;; Så det skjer på vei _inn_ fra markdown, ikke på vei ut.
+
+^{:nextjournal.clerk/visibility {:code :hide}}
+(clerk/html [:div {:style {:height "50vh"}}])

--- a/draft/mikrobloggeriet/teodor/markdown_compare.clj
+++ b/draft/mikrobloggeriet/teodor/markdown_compare.clj
@@ -1,0 +1,51 @@
+(ns mikrobloggeriet.teodor.markdown-compare
+  (:require
+   [nextjournal.clerk :as clerk]
+   [nextjournal.markdown :as md]
+   [nextjournal.markdown.transform]
+   [mikrobloggeriet.pandoc :as pandoc]))
+
+(def text1
+  "> et tout autour, la longue cohorte de ses personnages, avec leur histoire, leur passé, leurs légendes:
+> 1. Pélage vainqueur d'Alkhamah se faisant couronner à Covadonga
+> 2. La cantatrice exilée de Russie suivant Schönberg à Amsterdam
+> 3. Le petit chat sourd aux yeux vairons vivant au dernier étage
+> 4. ...
+
+**Georges Perec**, _La Vie mode d'emploi_.
+
+---
+")
+
+(def text2
+  "> et tout autour, la longue cohorte de ses personnages, avec leur histoire, leur passé, leurs légendes:
+>
+> 1. Pélage vainqueur d'Alkhamah se faisant couronner à Covadonga
+> 2. La cantatrice exilée de Russie suivant Schönberg à Amsterdam
+> 3. Le petit chat sourd aux yeux vairons vivant au dernier étage
+> 4. ...
+
+**Georges Perec**, _La Vie mode d'emploi_.
+
+---
+")
+
+(def convert-nextjournal
+  (comp nextjournal.markdown.transform/->hiccup nextjournal.markdown/parse))
+
+(def convert-pandoc
+  (comp pandoc/to-html pandoc/from-markdown))
+
+(clerk/example
+  (-> text1 convert-nextjournal clerk/html)
+  (-> text1 convert-pandoc clerk/html)
+
+  (-> text2 convert-nextjournal clerk/html)
+  (-> text2 convert-pandoc clerk/html)
+  )
+
+;; så, forskjellig konvensjon for når en punktliste starter, hvorvidt man skal
+;; kreve mellomrom eller ikke for å bryte opp overgangen mellom et avsnitt og en
+;; punktliste. Nice, TIL!
+
+;; hva med em-dash?

--- a/draft/mikrobloggeriet/teodor/markdown_compare.clj
+++ b/draft/mikrobloggeriet/teodor/markdown_compare.clj
@@ -49,3 +49,17 @@
 ;; punktliste. Nice, TIL!
 
 ;; hva med em-dash?
+
+(clerk/html (convert-pandoc "Dette er alt---la oss gå videre!"))
+
+;; funker som jeg liker i pandoc ☝️
+
+;; hva med Nextjournal/markdown?
+
+(clerk/html (convert-nextjournal "Dette er alt---la oss gå videre!"))
+
+;; nope, her trenger vi unicode em-dashes.
+
+(clerk/html (convert-nextjournal "Dette er alt—la oss gå videre!"))
+
+;; mmmmm.

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -18,7 +18,9 @@
    [pg.core :as pg]
    [reitit.core :as reitit]
    [reitit.ring]
-   [ring.middleware.cookies :as cookies]))
+   [ring.middleware.cookies :as cookies]
+   [nextjournal.markdown]
+   [nextjournal.markdown.transform]))
 
 (declare app)
 (declare url-for)
@@ -76,6 +78,13 @@
                        (let [pandoc (pandoc/from-markdown markdown)]
                          {:doc-html (pandoc/to-html pandoc)
                           :title (pandoc/infer-title pandoc)}))
+                     identity))
+
+(def markdown->html+info2
+  (cache/cache-fn-by (fn markdown->html+info [markdown]
+                       {:doc-html (-> markdown
+                                      nextjournal.markdown/parse
+                                      nextjournal.markdown.transform/->hiccup)})
                      identity))
 
 (defn cohort-rss-section [cohort]
@@ -244,34 +253,37 @@
 (defn doc
   [req cohort]
   (when-let [slug (http/path-param req :slug)]
-    (let [doc (doc/from-slug slug)
+    (let [markdown-parser-fn (if (str/includes? (:query-string req) "markdown-parser=nextjournal")
+                               markdown->html+info2
+                               markdown->html+info)
+          doc (doc/from-slug slug)
           {:keys [title doc-html]}
           (when (store/doc-exists? cohort doc)
-            (markdown->html+info (slurp (store/doc-md-path cohort doc))))]
+            (markdown-parser-fn (slurp (store/doc-md-path cohort doc))))]
       {:status 200
        :headers {"Content-Type" "text/html; charset=utf-8"}
        :body
        (page/html5
-        (into [:head] (concat (when title [[:title title]])
-                              (shared-html-header req)))
-        [:body
-         [:p (feeling-lucky "🎲")
-          " — "
-          [:a {:href "/"} "mikrobloggeriet"]
-          " "
-          [:a {:href (str "/" (cohort/slug cohort) "/")}
-           (cohort/slug cohort)]
-          " — "
-          [:span (let [previouse-number (dec (doc/number doc))
-                       prev (doc/from-slug (str (cohort/slug cohort) "-" previouse-number))]
-                   (when (store/doc-exists? cohort prev)
-                     [:span [:a {:href (str (store/doc-href cohort prev))} (doc/slug prev)] " · "]))]
-          [:span (:doc/slug doc)]
-          [:span (let [previouse-number (inc (doc/number doc))
-                       prev (doc/from-slug (str (cohort/slug cohort) "-" previouse-number))]
-                   (when (store/doc-exists? cohort prev)
-                     [:span " · " [:a {:href (str (store/doc-href cohort prev))}  (doc/slug prev)]]))]]
-         doc-html])})))
+           (into [:head] (concat (when title [[:title title]])
+                                 (shared-html-header req)))
+           [:body
+            [:p (feeling-lucky "🎲")
+             " — "
+             [:a {:href "/"} "mikrobloggeriet"]
+             " "
+             [:a {:href (str "/" (cohort/slug cohort) "/")}
+              (cohort/slug cohort)]
+             " — "
+             [:span (let [previouse-number (dec (doc/number doc))
+                          prev (doc/from-slug (str (cohort/slug cohort) "-" previouse-number))]
+                      (when (store/doc-exists? cohort prev)
+                        [:span [:a {:href (str (store/doc-href cohort prev))} (doc/slug prev)] " · "]))]
+             [:span (:doc/slug doc)]
+             [:span (let [previouse-number (inc (doc/number doc))
+                          prev (doc/from-slug (str (cohort/slug cohort) "-" previouse-number))]
+                      (when (store/doc-exists? cohort prev)
+                        [:span " · " [:a {:href (str (store/doc-href cohort prev))}  (doc/slug prev)]]))]]
+            doc-html])})))
 
 (defn random-doc [_req]
   (let [target (or

--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -250,12 +250,14 @@
 
   (store/cohort-href store/oj))
 
+
 (defn doc
   [req cohort]
   (when-let [slug (http/path-param req :slug)]
-    (let [markdown-parser-fn (if (str/includes? (:query-string req) "markdown-parser=nextjournal")
+    (let [markdown-parser-fn (if (some-> req :query-string (str/includes? "markdown-parser=nextjournal"))
                                markdown->html+info2
                                markdown->html+info)
+          _ (prn markdown-parser-fn)
           doc (doc/from-slug slug)
           {:keys [title doc-html]}
           (when (store/doc-exists? cohort doc)
@@ -444,3 +446,8 @@
 (comment
   ((app) {:uri "/deploy-info", :request-method :get})
   :rcf)
+
+(comment
+  (def app-instance (app))
+  (app-instance {:uri "/olorm/olorm-1/" :request-method :get})
+  :rfc)


### PR DESCRIPTION
From a rough set of benchmarks, `nextjournal/markdown` is:

- 7-80 times faster than mikrobloggeriet/pandoc
- implemented in pure clojure
- as pandoc, it supports an intermediate a data-based representation.

To activate the markdown browser, put `?markdown-parser=nextjournal` in the URL string.

Downsides for `nextjournal/markdown`:

1. Does not support automatically translating `---` to `—`.
2. Need to write logic to extract title again (doable :))