### PR TITLE
olorm-29: support spaces in arguments

### DIFF
--- a/o/olorm-29/index.md
+++ b/o/olorm-29/index.md
@@ -41,6 +41,7 @@ do
         ?) printf "Usage: $0 [-a] [-f file] args\n   or: $0 -V\n";;
     esac
 done
+shift $((OPTIND - 1))
 ```
 
 ## Konklusjon

--- a/o/olorm-29/index.md
+++ b/o/olorm-29/index.md
@@ -59,7 +59,8 @@ Jeg lekte meg med å bygge støtte for `--long-option` og kom opp med:
 
 ```
 # usage:
-# set -- $(parselong a/all f/file -- "$@")
+# args=$(parselong a/all f/file -- "$@")
+# eval "set -- $args"
 # while getopts f:a...
 parselong() {
     c=1
@@ -89,6 +90,12 @@ parselong() {
         esac
     done
     shift $c
+    for i; do
+        quoted=$(printf %s\\n "$i" \
+            | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/")
+        shift
+        set -- "$@" $quoted
+    done
     echo "$@"
 }
 ```


### PR DESCRIPTION
* 16eaea1 olorm-29: support spaces in arguments

parselong did not work well with spaces in arguments,
for example `--file "a b" "foo"` would be handled as `-f "a" "b" "foo"`

To solve this, every argument is returned with quotes,
and then passed to `eval "set -- `

* a210edc olorm-29: add shift after getopts
to make the example more complete and realistic